### PR TITLE
Added cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ If you wish to login with HTTP Basic Auth then crawl:
 ./xsscrapy.py -u http://example.com/login_page -l loginname --basic
 ```
 
+If you wish to use cookies:
+```shell
+./xsscrapy.py -u http://example.com/login_page --cookie "SessionID=abcdef1234567890"
+```
+
 If you wish to limit simultaneous connections to 20: 
 ```shell
 ./xsscrapy.py -u http://example.com -c 20

--- a/xsscrapy.py
+++ b/xsscrapy.py
@@ -19,6 +19,7 @@ def get_args():
     parser.add_argument('-c', '--connections', default='30', help="Set the max number of simultaneous connections allowed, default=30")
     parser.add_argument('-r', '--ratelimit', default='0', help="Rate in requests per minute, default=0")
     parser.add_argument('--basic', help="Use HTTP Basic Auth to login", action="store_true")
+    parser.add_argument('-k', '--cookie',help="Cookie key; --cookie SessionID=afgh3193e9103bca9318031bcdf")
     args = parser.parse_args()
     return args
 
@@ -28,9 +29,12 @@ def main():
     if rate not in [None, '0']:
         rate = str(60 / float(rate))
     try:
-        execute(['scrapy', 'crawl', 'xsscrapy', 
-                 '-a', 'url=%s' % args.url, '-a', 'user=%s' % args.login, '-a', 
-                 'pw=%s' % args.password, '-a', 'basic=%s' % args.basic, 
+        cookie_key = args.cookie.split('=',1)[0] if args.cookie else None
+        cookie_value = ''.join(args.cookie.split('=',1)[1:]) if args.cookie else None
+        execute(['scrapy', 'crawl', 'xsscrapy',
+                 '-a', 'url=%s' % args.url, '-a', 'user=%s' % args.login, '-a',
+                 'pw=%s' % args.password, '-a', 'basic=%s' % args.basic,
+                 '-a', 'cookie_key=%s' % cookie_key, '-a', 'cookie_value=%s' % cookie_value,
                  '-s', 'CONCURRENT_REQUESTS=%s' % args.connections,
                  '-s', 'DOWNLOAD_DELAY=%s' % rate])
     except KeyboardInterrupt:


### PR DESCRIPTION
Added:

- Accepting and passing cookies in xsscrapy.py
- Some parsing stuff in the xss_spider.py _init_ so we don't hit logouts, not sure if this is desirable but it made sense at the time
- The actual passing of the cookies in start_requests
- Usage of --cookies in README.md

I've made a bit of a mess of the xss_spider.start_requests to account for cookies, this logic can probably be cleaned up.

I used the COOKIES_DEBUG=true to debug and validate. I also routed requests through Burp to be extra sure and it looks like it is working. It could definitely take a second set of eyes before accepting though.

Cheers!