### PR TITLE
Switched to scrapy 1.1.0rc3 to fix SSL bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Scrapy==0.24.4
+Scrapy==1.1.0rc3
 pybloom==1.1
 requests
 beautifulsoup

--- a/xsscrapy/bloomfilters.py
+++ b/xsscrapy/bloomfilters.py
@@ -1,6 +1,6 @@
 from pybloom import BloomFilter
 from scrapy.utils.job import job_dir
-from scrapy.dupefilter import BaseDupeFilter
+from scrapy.dupefilters import BaseDupeFilter
 
 class BloomURLDupeFilter(BaseDupeFilter):
     """Request Fingerprint duplicates filter"""

--- a/xsscrapy/settings.py
+++ b/xsscrapy/settings.py
@@ -21,7 +21,7 @@ NEWSPIDER_MODULE = 'xsscrapy.spiders'
 # 200 (second): Make sure there's a random working User-Agent header set if that value's not injected with the test string
 DOWNLOADER_MIDDLEWARES = {'xsscrapy.middlewares.InjectedDupeFilter': 100,
                           'xsscrapy.middlewares.RandomUserAgentMiddleware': 200,
-                          'scrapy.contrib.downloadermiddleware.httpauth.HttpAuthMiddleware': 300}
+                          'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware': 300}
 
 COOKIES_ENABLED = True
 #COOKIES_DEBUG = True

--- a/xsscrapy/spiders/xss_spider.py
+++ b/xsscrapy/spiders/xss_spider.py
@@ -1,7 +1,7 @@
 # -- coding: utf-8 --
 
-from scrapy.contrib.linkextractors import LinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 from scrapy.http import FormRequest, Request
 from scrapy.selector import Selector
 from xsscrapy.items import inj_resp


### PR DESCRIPTION
Scrapy prior to 1.1.0rc3 had an issue where it would fail to connect to certain servers with an error stating ```<twisted.python.failure.Failure OpenSSL.SSL.Error: ('SSL routines', 'SSL3_READ_BYTES', 'sslv3 alert handshake failure'), ('SSL routines', 'SSL3_WRITE_BYTES', 'ssl handshake failure')>```. See https://github.com/scrapy/scrapy/issues/1764 for more info on this issue.

In that github issue, there were two potential solutions. Either add additional code forcing it to the correct code (see https://github.com/scrapy/scrapy/issues/1764#issuecomment-181950638). The other potential solution was upgrading to the latest release of scrapy.

There were pretty minimal changes needed to add support for 1.1.0rc3 (just changing import locations) so I went for that.