### PR TITLE
Switched to scrapy 1.1.0rc3 to fix SSL bug (Updated #31)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Scrapy==0.24.4
+Scrapy==1.1.0rc3
 pybloom==1.1
 requests
 beautifulsoup

--- a/xsscrapy/bloomfilters.py
+++ b/xsscrapy/bloomfilters.py
@@ -1,6 +1,6 @@
 from pybloom import BloomFilter
 from scrapy.utils.job import job_dir
-from scrapy.dupefilter import BaseDupeFilter
+from scrapy.dupefilters import BaseDupeFilter
 
 class BloomURLDupeFilter(BaseDupeFilter):
     """Request Fingerprint duplicates filter"""

--- a/xsscrapy/pipelines.py
+++ b/xsscrapy/pipelines.py
@@ -13,6 +13,7 @@ import itertools
 #from IPython import embed
 from socket import gaierror, gethostbyname
 from urlparse import urlparse
+from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG
 
 class XSSCharFinder(object):
     def __init__(self):
@@ -63,9 +64,9 @@ class XSSCharFinder(object):
             with open(self.filename, 'a+') as f:
                 f.write('\n')
                 f.write('URL: '+resp_url+'\n')
-                spider.log('    URL: '+resp_url+'\n', level='INFO')
+                spider.log('    URL: '+resp_url+'\n', level=INFO)
                 f.write(msg+'\n')
-                spider.log('    '+msg+'\n', level='INFO')
+                spider.log('    '+msg+'\n', level=INFO)
 
         # Now that we've checked for SQLi, we can lowercase the body
         body = body.lower()
@@ -999,37 +1000,37 @@ class XSSCharFinder(object):
             f.write('\n')
 
             f.write('URL: '+item['orig_url']+'\n')
-            spider.log('    URL: '+item['orig_url'], level='INFO')
+            spider.log('    URL: '+item['orig_url'], level=INFO)
 
             f.write('response URL: '+item['resp_url']+'\n')
-            spider.log('    response URL: '+item['resp_url'], level='INFO')
+            spider.log('    response URL: '+item['resp_url'], level=INFO)
 
             if 'POST_to' in item:
                 f.write('POST url: '+item['POST_to']+'\n')
-                spider.log('    POST url: '+item['POST_to'], level='INFO')
+                spider.log('    POST url: '+item['POST_to'], level=INFO)
 
             f.write('Unfiltered: '+item['unfiltered']+'\n')
-            spider.log('    Unfiltered: '+item['unfiltered'], level='INFO')
+            spider.log('    Unfiltered: '+item['unfiltered'], level=INFO)
 
             f.write('Payload: '+item['xss_payload']+'\n')
-            spider.log('    Payload: '+item['xss_payload'], level='INFO')
+            spider.log('    Payload: '+item['xss_payload'], level=INFO)
 
             f.write('Type: '+item['xss_place']+'\n')
-            spider.log('    Type: '+item['xss_place'], level='INFO')
+            spider.log('    Type: '+item['xss_place'], level=INFO)
 
             f.write('Injection point: '+item['xss_param']+'\n')
-            spider.log('    Injection point: '+item['xss_param'], level='INFO')
+            spider.log('    Injection point: '+item['xss_param'], level=INFO)
 
             if 'sugg_payloads' in item:
                 f.write('Possible payloads: '+item['sugg_payloads']+'\n')
-                spider.log('    Possible payloads: '+item['sugg_payloads'], level='INFO')
+                spider.log('    Possible payloads: '+item['sugg_payloads'], level=INFO)
 
             # Cut off the line at 500
             #f.write('Line: '+item['line'][-500:]+'\n')
             f.write('Line: '+item['line']+'\n')
-            spider.log('    Line: '+item['line'], level='INFO')
+            spider.log('    Line: '+item['line'], level=INFO)
 
             if 'error' in item:
                 f.write('Error: '+item['error']+'\n')
-                spider.log('    Error: '+item['error'], level='INFO')
+                spider.log('    Error: '+item['error'], level=INFO)
 

--- a/xsscrapy/settings.py
+++ b/xsscrapy/settings.py
@@ -21,7 +21,7 @@ NEWSPIDER_MODULE = 'xsscrapy.spiders'
 # 200 (second): Make sure there's a random working User-Agent header set if that value's not injected with the test string
 DOWNLOADER_MIDDLEWARES = {'xsscrapy.middlewares.InjectedDupeFilter': 100,
                           'xsscrapy.middlewares.RandomUserAgentMiddleware': 200,
-                          'scrapy.contrib.downloadermiddleware.httpauth.HttpAuthMiddleware': 300}
+                          'scrapy.downloadermiddlewares.httpauth.HttpAuthMiddleware': 300}
 
 COOKIES_ENABLED = True
 #COOKIES_DEBUG = True

--- a/xsscrapy/spiders/xss_spider.py
+++ b/xsscrapy/spiders/xss_spider.py
@@ -29,7 +29,8 @@ __author__ = 'Dan McInerney danhmcinerney@gmail.com'
 class XSSspider(CrawlSpider):
     name = 'xsscrapy'
     # Scrape 404 pages too
-    handle_httpstatus_list = [x for x in xrange(0,600)]
+    handle_httpstatus_list = [x for x in xrange(0,300)]+[x for x in xrange(400,600)]
+
 
     rules = (Rule(LinkExtractor(), callback='parse_resp', follow=True), )
 
@@ -172,10 +173,10 @@ class XSSspider(CrawlSpider):
             doc = lxml.html.fromstring(body, base_url=orig_url)
         except lxml.etree.ParserError:
             self.log('ParserError from lxml on %s' % orig_url)
-            return
+            return []
         except lxml.etree.XMLSyntaxError:
             self.log('XMLSyntaxError from lxml on %s' % orig_url)
-            return
+            return []
 
         forms = doc.xpath('//form')
         payload = self.test_str
@@ -309,6 +310,8 @@ class XSSspider(CrawlSpider):
                                                     'orig_url':orig_url,
                                                     'xss_place':'form',
                                                     'POST_to':url,
+                                                    'dont_redirect': True,
+                                                    'handle_httpstatus_list' : range(300,309),
                                                     'delim':payload[:len(self.delim)+2]},
                                               dont_filter=True,
                                               callback=self.xss_chars_finder)
@@ -334,6 +337,8 @@ class XSSspider(CrawlSpider):
                               'xss_param':xss_param,
                               'orig_url':url,
                               'payload':payload,
+                              'dont_redirect': True,
+                              'handle_httpstatus_list' : range(300,309),
                               'delim':payload[:len(self.delim)+2]},
                         cookies={'userinput':payload},
                         callback=self.xss_chars_finder,
@@ -558,6 +563,8 @@ class XSSspider(CrawlSpider):
                               'xss_param':url[1],
                               'orig_url':orig_url,
                               'payload':url[2],
+                              'dont_redirect': True,
+                              'handle_httpstatus_list' : range(300,309),
                               'delim':url[2][:len(self.delim)+2]},
                         callback = self.xss_chars_finder)
                         for url in payloaded_urls] # Meta is the payload
@@ -577,6 +584,8 @@ class XSSspider(CrawlSpider):
                               'orig_url':url,
                               'payload':payload,
                               'delim':payload[:len(self.delim)+2],
+                              'dont_redirect': True,
+                              'handle_httpstatus_list' : range(300,309),
                               'UA':self.get_user_agent(inj_header, payload)},
                         dont_filter=True,
                         callback = self.xss_chars_finder)

--- a/xsscrapy/spiders/xss_spider.py
+++ b/xsscrapy/spiders/xss_spider.py
@@ -1,7 +1,7 @@
 # -- coding: utf-8 --
 
-from scrapy.contrib.linkextractors import LinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 from scrapy.http import FormRequest, Request
 from scrapy.selector import Selector
 from xsscrapy.items import inj_resp


### PR DESCRIPTION
This is an updated and fixed version of #31. 

Scrapy prior to 1.1.0rc3 had an issue where it would fail to connect to certain servers with an error stating ```<twisted.python.failure.Failure OpenSSL.SSL.Error: ('SSL routines', 'SSL3_READ_BYTES', 'sslv3 alert handshake failure'), ('SSL routines', 'SSL3_WRITE_BYTES', 'ssl handshake failure')>```. See scrapy/scrapy#1764 for more info on this issue.

In that github issue, there were two potential solutions. Either add additional code forcing it to the correct code (see scrapy/scrapy#1764). The other potential solution was upgrading to the latest release of scrapy. Given this choice, went for upgrading scrapy. 

This required changing the locations of a few imports, updating the logging method, and fixing the redirection. 